### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   docker-build-test:

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 cd $(dirname $0)
 
 LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so ls -l /mnt
-LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so cat /mnt/Cargo.toml
+#LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so cat /mnt/Cargo.toml

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 cd $(dirname $0)
 
 LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so ls -l /mnt
-#LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so cat /mnt/Cargo.toml
+LIBZPHOOK=./target/debug/libndfuseshim.so LD_PRELOAD=./zpoline/libzpoline.so cat /mnt/Cargo.toml

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -17,6 +17,23 @@ pub trait BinSerdes: for<'a> Deserialize<'a> + Serialize + Sized {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Request {
+    pub kind: RequestKind,
+}
+impl BinSerdes for Request {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum RequestKind {
+    Init,
+    Statx(StatxRequest),
+    Fstat(FstatRequest),
+    Getdents64(Getdents64Request),
+    Open(OpenRequest),
+    Read(ReadRequest),
+    Close(CloseRequest),
+}
+
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum ShimOpcode {
@@ -35,12 +52,6 @@ pub enum StatusCode {
     OK = 1,
     ERROR = 2,
 }
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Request {
-    pub opcode: ShimOpcode,
-}
-impl BinSerdes for Request {}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Response {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -96,7 +96,7 @@ impl BinSerdes for FstatRequest {}
 // refer to lkl/linux/tools/lkl/include/lkl/asm-generic/stat.h
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct stat {
+pub struct Stat {
     pub st_dev: u64,
     pub st_ino: u64,
     pub st_mode: u32,
@@ -104,9 +104,11 @@ pub struct stat {
     pub st_uid: u32,
     pub st_gid: u32,
     pub st_rdev: u64,
+    #[serde(skip)]
     __pad1: u64,
     pub st_size: i64,
     pub st_blksize: i32,
+    #[serde(skip)]
     __pad2: u32,
     pub st_blocks: i64,
     pub st_atime: i64,
@@ -118,7 +120,7 @@ pub struct stat {
     #[serde(skip)]
     __unused: [c_uint; 2],
 }
-impl BinSerdes for stat {}
+impl BinSerdes for Stat {}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OpenRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,9 @@ pub unsafe extern "C" fn __hook_init(
         }
         Err(e) => {
             eprintln!("Filesystem initialization failed: {}", e);
-            return -1;
+
+            // Not to return '-1' to avoid hang-up
+            return 0;
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,14 @@
+use crate::lklfs::LKLFS;
 use libc::{c_char, c_int, c_long, c_uint, c_void, mode_t, size_t};
+use log::debug;
+use std::env;
 use std::fs;
 use std::io::Write;
 use std::sync::{LazyLock, Mutex};
 mod ipc;
 mod lklfs;
 
-static FS: LazyLock<Mutex<lklfs::LKLFS>> = LazyLock::new(|| {
-    Mutex::new(lklfs::LKLFS::new(
-        env::var("NDFUSE_SOCKET_PATH").unwrap_or_else(|_| "/tmp/ndfuse.sock".to_string()),
-        env::var("NDFUSE_LKLFS_LOG_PATH")
-            .unwrap_or_else(|_| "/tmp/ndfuse-shim-lklfs.log".to_string()),
-    ))
-});
-
-use std::env;
+static FS: LazyLock<Mutex<Option<LKLFS>>> = LazyLock::new(|| Mutex::new(None));
 
 type SyscallFn = extern "C" fn(c_long, c_long, c_long, c_long, c_long, c_long, c_long) -> c_long;
 
@@ -31,21 +26,40 @@ extern "C" fn hook_function(
 ) -> c_long {
     unsafe {
         if let Some(original_syscall) = NEXT_SYS_CALL {
-            // 保存しておいた元の関数を呼び出します。
+            let mut fs_lock = match FS.lock() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    eprintln!("Failed to acquire FS lock: {}", e);
+                    return original_syscall(a1, a2, a3, a4, a5, a6, a7);
+                }
+            };
+            let fs = match fs_lock.as_mut() {
+                None => {
+                    eprintln!("Filesystem not initialized");
+                    return original_syscall(a1, a2, a3, a4, a5, a6, a7);
+                }
+                Some(f) => f,
+            };
+
             let res: Option<i64> = if a1 == syscall_numbers::x86_64::SYS_open {
-                unimplemented!("open called");
+                debug!("open called");
+                fs.open(a2 as *const c_char, a3 as c_int, a4 as mode_t)
             } else if a1 == syscall_numbers::x86_64::SYS_openat {
-                println!("openat called");
-                openat(a2 as c_int, a3 as *const c_char, a4 as c_int, a5 as mode_t)
+                debug!("openat called");
+                if a2 as c_int == libc::AT_FDCWD {
+                    fs.open(a3 as *const c_char, a4 as c_int, a5 as mode_t)
+                } else {
+                    None
+                }
             } else if a1 == syscall_numbers::x86_64::SYS_read {
-                println!("read called");
-                read(a2 as c_int, a3 as *mut c_void, a4 as size_t)
+                debug!("read called");
+                fs.read(a2 as c_int, a3 as *mut c_void, a4 as size_t)
             } else if a1 == syscall_numbers::x86_64::SYS_fstat {
-                println!("fstat called");
-                fstat(a2 as c_int, a3 as *mut libc::stat)
+                debug!("fstat called");
+                fs.fstat(a2 as c_int, a3 as *mut libc::stat)
             } else if a1 == syscall_numbers::x86_64::SYS_statx {
-                println!("statx called");
-                statx(
+                debug!("statx called");
+                fs.statx(
                     a2 as c_int,
                     a3 as *const c_char,
                     a4 as c_int,
@@ -53,22 +67,22 @@ extern "C" fn hook_function(
                     a6 as *mut libc::statx,
                 )
             } else if a1 == syscall_numbers::x86_64::SYS_getdents64 {
-                println!("getdents64 called");
-                getdents64(a2 as c_int, a3 as *mut libc::dirent64, a4 as usize)
+                debug!("getdents64 called");
+                fs.getdents64(a2 as c_int, a3 as *mut libc::dirent64, a4 as usize)
             } else if a1 == syscall_numbers::x86_64::SYS_lgetxattr {
-                println!("lgetxattr called");
-                lgetxattr(
+                debug!("lgetxattr called");
+                fs.lgetxattr(
                     a2 as *const c_char,
                     a3 as *const c_char,
                     a4 as *mut std::ffi::c_void,
                     a5 as size_t,
                 )
             } else if a1 == syscall_numbers::x86_64::SYS_listxattr {
-                println!("listxattr called");
-                listxattr(a2 as *const c_char, a3 as *mut c_char, a4 as usize)
+                debug!("listxattr called");
+                fs.listxattr(a2 as *const c_char, a3 as *mut c_char, a4 as usize)
             } else if a1 == syscall_numbers::x86_64::SYS_close {
-                println!("close called");
-                close(a2 as c_int)
+                debug!("close called");
+                fs.close(a2 as c_int)
             } else {
                 Some(original_syscall(a1, a2, a3, a4, a5, a6, a7))
             };
@@ -121,110 +135,14 @@ fn init() -> Result<(), anyhow::Error> {
 
     writeln!(log, "[INIT] ndfuse-shim library loaded").ok();
 
-    match FS.lock().unwrap().init() {
-        Ok(_) => {}
-        Err(e) => {
-            writeln!(log, "[INIT] Filesystem initialization failed: {}", e).ok();
-            return Err(e);
-        }
-    };
+    let fs = LKLFS::new(
+        env::var("NDFUSE_SOCKET_PATH").unwrap_or_else(|_| "/tmp/ndfuse.sock".to_string()),
+        env::var("NDFUSE_LKLFS_LOG_PATH")
+            .unwrap_or_else(|_| "/tmp/ndfuse-shim-lklfs.log".to_string()),
+    )?;
+    FS.lock().unwrap().replace(fs);
 
     writeln!(log, "[INIT] Filesystem hooks initialized successfully").ok();
 
     Ok(())
-}
-
-pub fn statx(
-    dirfd: c_int,
-    pathname: *const c_char,
-    flags: c_int,
-    mask: c_uint,
-    statxbuf: *mut libc::statx,
-) -> Option<i64> {
-    if let Some(d) = FS
-        .lock()
-        .unwrap()
-        .statx(dirfd, pathname, flags, mask, statxbuf)
-    {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-pub fn fstat(fd: c_int, stat: *mut libc::stat) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().fstat(fd, stat) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-fn lgetxattr(
-    path: *const c_char,
-    name: *const c_char,
-    value: *mut std::ffi::c_void,
-    size: libc::size_t,
-) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().lgetxattr(path, name, value, size) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-fn listxattr(path: *const c_char, list: *mut c_char, size: usize) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().listxattr(path, list, size) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-fn open(path: *const c_char, flags: c_int, mode: mode_t) -> Option<i64> {
-    // Variable arguments handling for mode
-    let mode: Option<mode_t> = if flags & libc::O_CREAT != 0 {
-        Some(mode)
-    } else {
-        None
-    };
-
-    if let Some(d) = FS.lock().unwrap().open(path, flags, mode) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-// Also hook openat for completeness
-fn openat(dirfd: c_int, path: *const c_char, flags: c_int, mode: mode_t) -> Option<i64> {
-    if dirfd == libc::AT_FDCWD {
-        // If dirfd is AT_FDCWD, we can use the original open function
-        return open(path, flags, mode);
-    }
-    return None;
-}
-
-fn close(fd: c_int) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().close(fd) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-fn read(fd: c_int, buf: *mut c_void, count: size_t) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().read(fd, buf, count) {
-        return Some(d);
-    } else {
-        return None;
-    }
-}
-
-fn getdents64(fd: c_int, dirent: *mut libc::dirent64, count: usize) -> Option<i64> {
-    if let Some(d) = FS.lock().unwrap().getdents64(fd, dirent, count) {
-        return Some(d);
-    } else {
-        return None;
-    }
 }

--- a/src/lklfs.rs
+++ b/src/lklfs.rs
@@ -21,8 +21,6 @@ pub struct LKLFS {
 
 pub struct FileHandle {
     fh: u64,
-    _path: PathBuf,
-    _offset: u64,
 }
 
 fn init_logger(log_path: &str) {
@@ -355,14 +353,10 @@ impl LKLFS {
                 return None;
             }
         };
-        self.fds.lock().unwrap().insert(
-            fd as i32,
-            FileHandle {
-                fh: retval as u64,
-                _path: abs_path,
-                _offset: 0,
-            },
-        );
+        self.fds
+            .lock()
+            .unwrap()
+            .insert(fd as i32, FileHandle { fh: retval as u64 });
 
         Some(fd)
     }

--- a/src/lklfs.rs
+++ b/src/lklfs.rs
@@ -331,7 +331,7 @@ impl LKLFS {
                 match ipc::get_response_unit!(&buf[0..read_size], ResponseKind::Open) {
                     Ok(response) => response,
                     Err(e) => {
-                        error!("failed to parse fstat response data: {}", e);
+                        error!("failed to parse open response data: {}", e);
                         return None;
                     }
                 }
@@ -536,12 +536,12 @@ impl LKLFS {
             {
                 Ok(response) => response,
                 Err(e) => {
-                    error!("failed to parse read response data: {}", e);
+                    error!("failed to parse getdents64 response data: {}", e);
                     return None;
                 }
             },
             Err(e) => {
-                error!("failed to read read response: {}", e);
+                error!("failed to read getdents64 response: {}", e);
                 return None;
             }
         };


### PR DESCRIPTION
This pull request introduces major refactoring and improvements to the IPC protocol and filesystem initialization logic, aiming for a more robust, extensible, and maintainable codebase. The most significant changes include a redesign of the IPC request/response types for extensibility, refactoring of the filesystem initialization and hook logic, and various code cleanups. Below are the most important changes grouped by theme:

**IPC Protocol Redesign and Improvements**
- Replaces the old `ShimOpcode`-based request/response protocol with extensible `RequestKind` and `ResponseKind` enums, allowing for richer and more flexible message types. This includes new macros for response handling and a more structured approach to error and data handling. [[1]](diffhunk://#diff-87515f8480694fa5e2ccc9cb29345f0b93c1e3b85617d7ce5bdfb3197d31ab0bR15-L67) [[2]](diffhunk://#diff-87515f8480694fa5e2ccc9cb29345f0b93c1e3b85617d7ce5bdfb3197d31ab0bL76-R152) [[3]](diffhunk://#diff-87515f8480694fa5e2ccc9cb29345f0b93c1e3b85617d7ce5bdfb3197d31ab0bL110-L139)
- Updates the serialization/deserialization logic and data structures to match the new protocol, and adapts the `StatxRequest`, `Stat`, and related types accordingly. [[1]](diffhunk://#diff-87515f8480694fa5e2ccc9cb29345f0b93c1e3b85617d7ce5bdfb3197d31ab0bL76-R152) [[2]](diffhunk://#diff-87515f8480694fa5e2ccc9cb29345f0b93c1e3b85617d7ce5bdfb3197d31ab0bL110-L139)

**Filesystem Initialization and Hook Refactoring**
- Changes the global filesystem state `FS` to use `Option<LKLFS>` and defers initialization, improving error handling and making initialization more robust. Initialization now constructs the `LKLFS` object only once and handles failures gracefully. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1-R11) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L124-L230)
- Refactors the syscall hook logic to always delegate to the `LKLFS` instance, removing duplicated syscall handling functions and ensuring consistent error/log handling. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L34-R85) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L124-L230)

**LKLFS Implementation Updates**
- Refactors `LKLFS` to always maintain an active connection (not `Option`), simplifies logger initialization, and updates the initialization sequence to use the new IPC protocol. [[1]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1R1-R6) [[2]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L14-R26) [[3]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L52-L63) [[4]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L75-R67) [[5]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L99-R111)
- Updates all methods in `LKLFS` to use the new request/response types and response macros for more robust error handling and code clarity. [[1]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L177-R153) [[2]](diffhunk://#diff-bde718e6ee50c3f74c3c031dfd0dc3bbf6f6904f0542a3c52b9afe2d0c3c24a1L203-R182)

**Workflow and Miscellaneous**
- Removes the restriction that GitHub Actions only run on pull requests targeting `main`, enabling workflow runs on all PRs.

These changes collectively modernize the IPC layer, improve error handling, and make the filesystem integration more reliable and maintainable.