### PR TITLE
Add a test with a 10MiB file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bin filter=lfs diff=lfs merge=lfs -text

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,5 +19,7 @@ sleep 1
 
 run_cmd_and_compare_diff "ls -l -R"
 run_cmd_and_compare_diff "cat testdir/FILE1.txt"
+run_cmd_and_compare_diff "cat testdir/10MiB.bin"
+run_cmd_and_compare_diff "sha256sum testdir/10MiB.bin"
 
 kill $PROXY_PID

--- a/test/testdir/10MiB.bin
+++ b/test/testdir/10MiB.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:778e664c1e25394583506e29dec43fb45a5d720336142c33a2353f493470702a
+size 10485760


### PR DESCRIPTION
This pull request adds support for handling large binary files using Git LFS and updates the test suite to include a large binary file and its verification. The main changes are grouped into Git LFS integration and test suite enhancements:

**Git LFS Integration:**

* Added a `.gitattributes` entry to track all `.bin` files using Git LFS, ensuring large binaries are managed efficiently.
* Added a Git LFS pointer file for `test/testdir/10MiB.bin`, representing a 10 MiB binary file in the repository.

**Test Suite Enhancements:**

* Updated `test/test.sh` to include commands for displaying and verifying the contents and checksum of the new `10MiB.bin` file, improving test coverage for binary files.